### PR TITLE
Bring in gomod changes

### DIFF
--- a/boilerplate/lyft/golang_dockerfile/Dockerfile.GoTemplate
+++ b/boilerplate/lyft/golang_dockerfile/Dockerfile.GoTemplate
@@ -5,14 +5,14 @@
 
 # Using go1.10.4
 FROM golang:1.10.4-alpine3.8 as builder
-RUN apk add git openssh-client make curl dep
+RUN apk add git openssh-client make curl
 
-# COPY only the dep files for efficient caching
-COPY Gopkg.* /go/src/github.com/lyft/{{REPOSITORY}}/
+# COPY only the go mod files for efficient caching
+COPY go.mod go.sum /go/src/github.com/lyft/{{REPOSITORY}}/
 WORKDIR /go/src/github.com/lyft/{{REPOSITORY}}
 
 # Pull dependencies
-RUN dep ensure -vendor-only
+RUN go mod download
 
 # COPY the rest of the source code
 COPY . /go/src/github.com/lyft/{{REPOSITORY}}/

--- a/boilerplate/lyft/golang_test_targets/Makefile
+++ b/boilerplate/lyft/golang_test_targets/Makefile
@@ -3,12 +3,11 @@
 # 
 # TO OPT OUT OF UPDATES, SEE https://github.com/lyft/boilerplate/blob/master/Readme.rst
 
-DEP_SHA=1f7c19e5f52f49ffb9f956f64c010be14683468b
 
 .PHONY: lint
 lint: #lints the package for common code smells
-	which golangci-lint || curl -sfL https://install.goreleaser.com/github.com/golangci/golangci-lint.sh | bash -s -- -b $$GOPATH/bin v1.16.0
-	golangci-lint run --exclude deprecated
+	which golangci-lint || go install github.com/golangci/golangci-lint/cmd/golangci-lint
+	GL_DEBUG=linters_output,env golangci-lint run --deadline=5m --exclude deprecated -v
 
 # If code is failing goimports linter, this will fix.
 # skips 'vendor'
@@ -18,8 +17,7 @@ goimports:
 
 .PHONY: install
 install: #download dependencies (including test deps) for the package
-	which dep || (curl "https://raw.githubusercontent.com/golang/dep/${DEP_SHA}/install.sh" | sh)
-	dep ensure
+	go mod download
 
 .PHONY: test_unit
 test_unit:

--- a/boilerplate/lyft/golang_test_targets/Readme.rst
+++ b/boilerplate/lyft/golang_test_targets/Readme.rst
@@ -1,7 +1,7 @@
 Golang Test Targets
 ~~~~~~~~~~~~~~~~~~~
 
-Provides an ``install`` make target that uses ``dep`` install golang dependencies.
+Provides an ``install`` make target that uses ``go mod`` to install golang dependencies.
 
 Provides a ``lint`` make target that uses golangci to lint your code.
 
@@ -17,7 +17,7 @@ Provides a ``test_benchmark`` target for benchmark tests.
 
 Add ``lyft/golang_test_targets`` to your ``boilerplate/update.cfg`` file.
 
-Make sure you're using ``dep`` for dependency management.
+Make sure you're using ``go mod`` for dependency management.
 
 Provide a ``.golangci`` configuration (the lint target requires it).
 


### PR DESCRIPTION
This updates the boilerplate to use go modules instead of dep and follows the changes that have already been made:

* lyft/datacatalog#21
* lyft/flytepropeller#38
* lyft/flyteadmin#35
* lyft/flyteplugins#36
* lyft/flytestdlib#50
* lyft/flyteidl#27 (depends on lyft/flytestdlib#50 to be merged and released)
