### PR TITLE
Fixing uniqueness issue with package names in github workflows

### DIFF
--- a/boilerplate/lyft/github_workflows/Readme.rst
+++ b/boilerplate/lyft/github_workflows/Readme.rst
@@ -7,7 +7,7 @@ Provides a two github actions workflows.
 
 Add ``lyft/github_workflows`` to your ``boilerplate/update.cfg`` file.
 
-Add a github secret ``package_name`` with a the name of your fork (e.g. ``flytepropeller``).
+Add a github secret ``package_name`` with the name to use for publishing (e.g. ``flytepropeller``). Typicaly, this will be the same name as the repository.
 
 The actions will push to 2 repos:
 

--- a/boilerplate/lyft/github_workflows/Readme.rst
+++ b/boilerplate/lyft/github_workflows/Readme.rst
@@ -9,6 +9,8 @@ Add ``lyft/github_workflows`` to your ``boilerplate/update.cfg`` file.
 
 Add a github secret ``package_name`` with the name to use for publishing (e.g. ``flytepropeller``). Typicaly, this will be the same name as the repository.
 
+*Note*: If you are working on a fork, include that prefix in your package name (``myfork/flytepropeller``).
+
 The actions will push to 2 repos:
 
 	1. ``docker.pkg.github.com/lyft/<repo>/<package_name>``

--- a/boilerplate/lyft/github_workflows/Readme.rst
+++ b/boilerplate/lyft/github_workflows/Readme.rst
@@ -7,12 +7,12 @@ Provides a two github actions workflows.
 
 Add ``lyft/github_workflows`` to your ``boilerplate/update.cfg`` file.
 
-Add a github secret ``flytegithub_repo`` with a the name of your fork (e.g. ``my_company/flytepropeller``).
+Add a github secret ``package_name`` with a the name of your fork (e.g. ``flytepropeller``).
 
 The actions will push to 2 repos:
 
-	1. ``docker.pkg.github.com/lyft/<repo>/operator``
-	2. ``docker.pkg.github.com/lyft/<repo>/operator-stages`` : this repo is used to cache build stages to speed up iterative builds after.
+	1. ``docker.pkg.github.com/lyft/<repo>/<package_name>``
+	2. ``docker.pkg.github.com/lyft/<repo>/<package_name>-stages`` : this repo is used to cache build stages to speed up iterative builds after.
 
 There are two workflows that get deployed:
 

--- a/boilerplate/lyft/github_workflows/master.yml
+++ b/boilerplate/lyft/github_workflows/master.yml
@@ -24,7 +24,7 @@ jobs:
         with:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.flytegithub_repo }}/operator
+          image_name: ${{ secrets.package_name }}
           image_tag: latest,${{ github.sha }},${{ steps.bump-version.outputs.tag }}
           push_git_tag: true
           registry: docker.pkg.github.com

--- a/boilerplate/lyft/github_workflows/pull_request.yml
+++ b/boilerplate/lyft/github_workflows/pull_request.yml
@@ -13,7 +13,7 @@ jobs:
         with:
           username: "${{ github.actor }}"
           password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.flytegithub_repo }}/operator
+          image_name: ${{ secrets.package_name }}
           image_tag: ${{ github.sha }}
           push_git_tag: true
           registry: docker.pkg.github.com


### PR DESCRIPTION
It's not clear from the docs, but the last portion of the package name published to GH needs to be unique (at least within an organization?). I'm updating the two scripts to remove the `operator` suffix, and also renaming the secret to be more descriptive about what it controls (`flytegithub_repo` -> `package_name`).