### PR TITLE
Remove user github secret dependancy

### DIFF
--- a/boilerplate/lyft/github_workflows/master.yml
+++ b/boilerplate/lyft/github_workflows/master.yml
@@ -19,13 +19,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           WITH_V: true
           DEFAULT_BUMP: patch
-      - name: Push Docker Image to Github Registry
-        uses: whoan/docker-build-with-cache-action@v5
+
+      - id: cache-docker
+        uses: actions/cache@v1
         with:
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.package_name }}
-          image_tag: latest,${{ github.sha }},${{ steps.bump-version.outputs.tag }}
-          push_git_tag: true
-          registry: docker.pkg.github.com
-          build_extra_args: "--compress=true"
+          path: /tmp//tmp/docker-images
+          key: /tmp/docker-images-${{ hashFiles('Dockerfile') }}
+
+      - run: docker load -i /tmp//tmp/docker-images/snapshot-builder.tar || true
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+      - run: |
+          docker build -t lyft/${{ secrets.package_name }}:${{ github.sha }} . --target builder --cache-from=flytepropeller-cache
+          docker build -t lyft/${{ secrets.package_name }}:${{ github.sha }} .
+      - run: docker tag lyft/${{ secrets.package_name }}:${{ github.sha }} ${{ secrets.package_name }}-cache && mkdir -p /tmp//tmp/docker-images && docker save flytepropeller-cache -o /tmp//tmp/docker-images/snapshot.tar && ls -lh /tmp//tmp/docker-images || true
+        if: always() && steps.cache-docker.outputs.cache-hit != 'true'
+

--- a/boilerplate/lyft/github_workflows/pull_request.yml
+++ b/boilerplate/lyft/github_workflows/pull_request.yml
@@ -8,12 +8,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v1
-      - name: Push Docker Image to Github Registry
-        uses: whoan/docker-build-with-cache-action@v5
+      - id: cache-docker
+        uses: actions/cache@v1
         with:
-          username: "${{ github.actor }}"
-          password: "${{ secrets.GITHUB_TOKEN }}"
-          image_name: ${{ secrets.package_name }}
-          image_tag: ${{ github.sha }}
-          push_git_tag: true
-          registry: docker.pkg.github.com
+          path: /tmp//tmp/docker-images
+          key: /tmp/docker-images-${{ hashFiles('Dockerfile') }}
+
+      - run: docker load -i /tmp//tmp/docker-images/snapshot-builder.tar || true
+        if: steps.cache-docker.outputs.cache-hit == 'true'
+      - run: |
+          docker build -t lyft/${{ secrets.package_name }}:${{ github.sha }} . --target builder --cache-from=flytepropeller-cache
+          docker build -t lyft/${{ secrets.package_name }}:${{ github.sha }} .
+      - run: docker tag lyft/${{ secrets.package_name }}:${{ github.sha }} ${{ secrets.package_name }}-cache && mkdir -p /tmp//tmp/docker-images && docker save flytepropeller-cache -o /tmp//tmp/docker-images/snapshot.tar && ls -lh /tmp//tmp/docker-images || true
+        if: always() && steps.cache-docker.outputs.cache-hit != 'true'
+


### PR DESCRIPTION
Current github pipeline depends upon user github secrets. Before creating a pr evry developer has to setup secret inside their github repository. 

This pr try to remove all those dependancy 